### PR TITLE
FIX: don't add the prefix on this PV

### DIFF
--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -480,7 +480,7 @@ class DelayMacro(CalibMotor, DelayTowerMacro):
     #                        "t4: {1:.3f}ps".format(t1_delay, t4_delay))
     #     return is_aligned
 
-    calib_detector = Cmp(PCDSDetector, 'XCS:USR:O1000:01')
+    calib_detector = Cmp(PCDSDetector, 'XCS:USR:O1000:01', add_prefix=[])
 
     def __init__(self, prefix, name=None, *args, **kwargs):
         super().__init__(prefix, name=name, *args, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Bug I missed in my crusade to ophyd=1.2.0. The sndsystem fails to load because XCS:SND<opalPV> doesn't exist.