### PR TITLE
FIX: ophyd signal .value deprecation -> .get()

### DIFF
--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -84,7 +84,7 @@ class AeroBase(SndEpicsMotor):
         ----------
         status : StatusObject or list
             The inputted status object.
-        
+
         msg : str or None, optional
             Message to print if print_set is True.
 
@@ -103,7 +103,7 @@ class AeroBase(SndEpicsMotor):
         Returns
         -------
         Status
-            Inputted status object.        
+            Inputted status object.
         """
         try:
             # Wait for the status to complete
@@ -139,7 +139,7 @@ class AeroBase(SndEpicsMotor):
 
         print_set : bool, optional
             Print a short statement about the set.
-        
+
         check_status : bool, optional
             Check if the motors are in a valid state to move.
 
@@ -147,7 +147,7 @@ class AeroBase(SndEpicsMotor):
         -------
         Status : StatusObject
             Status of the set.
-        """        
+        """
         # Check the motor status
         if check_status:
             self.check_status()
@@ -159,7 +159,7 @@ class AeroBase(SndEpicsMotor):
     def homr(self, ret_status=False, print_set=True, check_status=True):
         """
         Home the motor in reverse.
-        
+
         Parameters
         ----------
         ret_status : bool, optional
@@ -183,7 +183,7 @@ class AeroBase(SndEpicsMotor):
         return self._status_print(status, "Homing '{0}' in reverse.".format(
             self.desc), print_set=print_set, ret_status=ret_status)
 
-    def move(self, position, wait=False, check_status=True, timeout=None, *args, 
+    def move(self, position, wait=False, check_status=True, timeout=None, *args,
              **kwargs):
         """
         Move to a specified position, optionally waiting for motion to
@@ -211,17 +211,17 @@ class AeroBase(SndEpicsMotor):
 
         Returns
         -------
-        status : MoveStatus        
+        status : MoveStatus
             Status object for the move.
-        
+
         Raises
         ------
         TimeoutError
             When motion takes longer than `timeout`
-        
+
         ValueError
             On invalid positions
-        
+
         RuntimeError
             If motion fails other than timing out
         """
@@ -229,7 +229,7 @@ class AeroBase(SndEpicsMotor):
         if check_status:
             self.check_status(position)
         logger.debug("Moving {0} to {1}".format(self.name, position))
-        return super().move(position, wait=wait, timeout=timeout, *args, 
+        return super().move(position, wait=wait, timeout=timeout, *args,
                             **kwargs)
 
     def mv(self, position, wait=True, print_move=True,
@@ -260,7 +260,7 @@ class AeroBase(SndEpicsMotor):
         -----------------
         LimitError
             Error raised when the inputted position is beyond the soft limits.
-        
+
         MotorDisabled
             Error raised if the motor is disabled and move is requested.
 
@@ -272,7 +272,7 @@ class AeroBase(SndEpicsMotor):
 
         Returns
         -------
-        status : MoveStatus        
+        status : MoveStatus
             Status object for the move.
         """
         try:
@@ -286,7 +286,7 @@ class AeroBase(SndEpicsMotor):
                     logger.info("Move command sent to '{0}'.".format(self.desc))
             return status
 
-        # Catch all the common motor exceptions        
+        # Catch all the common motor exceptions
         except LimitError:
             logger.warning("Requested move '{0}' is outside the soft limits "
                            "{1} for motor {2}".format(position, self.limits,
@@ -316,7 +316,7 @@ class AeroBase(SndEpicsMotor):
         ------
         MotorDisabled
             If the motor is disabled.
-        
+
         MotorFaulted
             If the motor is faulted.
 
@@ -337,18 +337,18 @@ class AeroBase(SndEpicsMotor):
             err = "Motor '{0}' is currently stopped.".format(self.desc)
             logger.error(err)
             raise MotorStopped(err)
-        
+
         # Check if the current position is valid
         self.check_value(self.position)
         # Check if the move position is valid
-        if position: 
+        if position:
             self.check_value(position)
-        
+
     def set_position(self, position_des, print_set=True):
         """
-        Sets the current position to be the inputted position by changing the 
+        Sets the current position to be the inputted position by changing the
         offset.
-        
+
         Parameters
         ----------
         position_des : float
@@ -359,7 +359,7 @@ class AeroBase(SndEpicsMotor):
             log_level = logger.info
         else:
             log_level = logger.debug
-        
+
         log_level("'{0}' previous position: {0}, offset: {1}".format(
             self.position, self.offset))
         self.offset += position_des - self.position
@@ -418,7 +418,7 @@ class AeroBase(SndEpicsMotor):
         enabled : bool
             True if the motor is powered, False if not.
         """
-        return bool(self.power.value)
+        return bool(self.power.get())
 
     def clear(self, ret_status=False, print_set=True):
         """
@@ -466,17 +466,17 @@ class AeroBase(SndEpicsMotor):
     def faulted(self):
         """
         Returns the current fault with the motor.
-        
+
         Returns
         -------
         faulted
             Fault enumeration.
         """
         if self.axis_fault.connected:
-            return bool(self.axis_fault.value)
+            return bool(self.axis_fault.get())
         else:
             return None
-    
+
     def zero_all(self, ret_status=False, print_set=True):
         """
         Sets the current position to be the zero position of the motor.
@@ -491,7 +491,7 @@ class AeroBase(SndEpicsMotor):
 
         Returns
         -------
-        status : StatusObject        
+        status : StatusObject
             Status object for the set.
         """
         status = self.zero_all_proc.set(1, timeout=self.set_timeout)
@@ -516,13 +516,13 @@ class AeroBase(SndEpicsMotor):
         """
         Sets the state of the motor. Inputted state can be one of the following
         states or the index of the desired state:
-            'Stop', 'Pause', 'Move', 'Go'            
+            'Stop', 'Pause', 'Move', 'Go'
         Alias for set_state((val, False, True)
-        
+
         Parameters
         ----------
         val : int or str
-        
+
         ret_status : bool, optional
             Return the status object of the set.
 
@@ -532,7 +532,7 @@ class AeroBase(SndEpicsMotor):
         Returns
         -------
         Status
-            The status object for setting the state signal.        
+            The status object for setting the state signal.
         """
         try:
             return self.set_state(val, ret_status, print_set)
@@ -544,12 +544,12 @@ class AeroBase(SndEpicsMotor):
         """
         Sets the state of the motor. Inputted state can be one of the following
         states or the index of the desired state:
-            'Stop', 'Pause', 'Move', 'Go'            
-        
+            'Stop', 'Pause', 'Move', 'Go'
+
         Parameters
         ----------
         val : int or str
-        
+
         ret_status : bool, optional
             Return the status object of the set.
 
@@ -559,7 +559,7 @@ class AeroBase(SndEpicsMotor):
         Returns
         -------
         Status
-            The status object for setting the state signal.        
+            The status object for setting the state signal.
         """
         # Make sure it is in title case if it's a string
         val = state
@@ -571,12 +571,12 @@ class AeroBase(SndEpicsMotor):
             error = "Invalid state inputted: '{0}'.".format(val)
             logger.error(error)
             raise ValueError(error)
-        
+
         # Lets enforce it's a string or value
         status = self.state_component.set(val, timeout=self.set_timeout)
 
         return self._status_print(
-            status, "Changed state of '{0} to '{1}'.".format(self.desc, val), 
+            status, "Changed state of '{0} to '{1}'.".format(self.desc, val),
             print_set=print_set, ret_status=ret_status)
 
     def ready_motor(self, ret_status=False, print_set=True):
@@ -595,13 +595,13 @@ class AeroBase(SndEpicsMotor):
         Returns
         -------
         Status
-            The status object for all the sets.        
+            The status object for all the sets.
         """
         status = [self.clear(ret_status=True, print_set=False)]
         status.append(self.enable(ret_status=True, print_set=False))
         status.append(self.set_state("Go", ret_status=True, print_set=False))
         return self._status_print(
-            status, "Motor '{0}' is now ready to move.".format(self.desc), 
+            status, "Motor '{0}' is now ready to move.".format(self.desc),
             print_set=print_set, ret_status=ret_status)
 
     def expert_screen(self, print_msg=True):
@@ -617,17 +617,17 @@ class AeroBase(SndEpicsMotor):
         if print_msg:
             logger.info("Launching expert screen.")
         os.system("{0} {1} {2} &".format(path, self.prefix, "aerotech"))
-     
-    def status(self, status="", offset=0, print_status=True, newline=False, 
+
+    def status(self, status="", offset=0, print_status=True, newline=False,
                short=False):
         """
         Returns the status of the device.
-        
+
         Parameters
         ----------
         status : str, optional
             The string to append the status to.
-            
+
         offset : int, optional
             Amount to offset each line of the status.
 
@@ -644,23 +644,23 @@ class AeroBase(SndEpicsMotor):
         """
         if short:
             status += "\n{0}{1:<16}|{2:^16.3f}|{3:^16.3f}".format(
-                " "*offset, self.desc, self.position, self.dial.value)
+                " "*offset, self.desc, self.position, self.dial.get())
         else:
             status += "{0}{1}\n".format(" "*offset, self.desc)
             status += "{0}PV: {1:>25}\n".format(" "*(offset+2), self.prefix)
-            status += "{0}Enabled: {1:>20}\n".format(" "*(offset+2), 
+            status += "{0}Enabled: {1:>20}\n".format(" "*(offset+2),
                                                      str(self.enabled))
-            status += "{0}Faulted: {1:>20}\n".format(" "*(offset+2), 
+            status += "{0}Faulted: {1:>20}\n".format(" "*(offset+2),
                                                      str(self.faulted))
-            status += "{0}State: {1:>22}\n".format(" "*(offset+2), 
+            status += "{0}State: {1:>22}\n".format(" "*(offset+2),
                                                      str(self.state))
-            status += "{0}Position: {1:>19}\n".format(" "*(offset+2), 
+            status += "{0}Position: {1:>19}\n".format(" "*(offset+2),
                                                       np.round(self.wm(), 6))
-            status += "{0}Dial: {1:>23}\n".format(" "*(offset+2), 
-                                                      np.round(self.dial.value,
+            status += "{0}Dial: {1:>23}\n".format(" "*(offset+2),
+                                                      np.round(self.dial.get(),
                                                                6))
             status += "{0}Limits: {1:>21}\n".format(
-                " "*(offset+2), str((int(self.low_limit), 
+                " "*(offset+2), str((int(self.low_limit),
                                      int(self.high_limit))))
 
         if newline:
@@ -688,7 +688,7 @@ class InterlockedAero(AeroBase):
         """
         Status check that also checks if the pressure measured by the pressure
         switch is good.
-        
+
         Parameters
         ----------
         position : float
@@ -698,7 +698,7 @@ class InterlockedAero(AeroBase):
         ------
         MotorDisabled
             If the motor is disabled.
-        
+
         MotorFaulted
             If the motor is faulted.
 
@@ -744,7 +744,7 @@ class InterlockedAero(AeroBase):
         -----------------
         LimitError
             Error raised when the inputted position is beyond the soft limits.
-        
+
         MotorDisabled
             Error raised if the motor is disabled and move is requested.
 
@@ -760,7 +760,7 @@ class InterlockedAero(AeroBase):
 
         Returns
         -------
-        status : MoveStatus        
+        status : MoveStatus
             Status object for the move.
         """
         try:
@@ -769,8 +769,8 @@ class InterlockedAero(AeroBase):
         except BadN2Pressure:
             logger.warning("Cannot move - pressure in tower {0} is bad.".format(
                 self._tower))
-            
-            
+
+
 class LinearAero(AeroBase):
     """
     Class for the aerotech linear stage.
@@ -798,7 +798,7 @@ class InterRotationAero(InterlockedAero, RotationAero):
     """
     pass
 
-    
+
 class DiodeAero(AeroBase):
     """
     VT50 Micronix Motor of the diodes

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -27,15 +27,15 @@ class EccController(SndDevice):
     _firm_month = Cmp(EpicsSignalRO, ":CALC:FIRMMONTH")
     _firm_year = Cmp(EpicsSignalRO, ":CALC:FIRMYEAR")
     _flash = Cmp(EpicsSignal, ":RDB:FLASH", write_pv=":CMD:FLASH")
-    
-    @property 
+
+    @property
     def firmware(self):
         """
         Returns the firmware in the same date format as the EDM screen.
         """
         return "{0}/{1}/{2}".format(
-            self._firm_day.value, self._firm_month.value, self._firm_year.value)
-    
+            self._firm_day.get(), self._firm_month.get(), self._firm_year.get())
+
     @property
     def flash(self):
         """
@@ -88,19 +88,19 @@ class EccBase(SndMotor, PositionerBase):
         position : float
             Current position of the motor.
         """
-        return self.user_readback.value
+        return self.user_readback.get()
 
     @property
     def reference(self):
         """
         Returns the reference position of the motor.
-        
+
         Returns
         -------
         position : float
             Reference position of the motor.
         """
-        return self.motor_reference_position.value
+        return self.motor_reference_position.get()
 
     @property
     def egu(self):
@@ -125,7 +125,7 @@ class EccBase(SndMotor, PositionerBase):
         ----------
         status : StatusObject or list
             The inputted status object.
-        
+
         msg : str or None, optional
             Message to print if print_set is True.
 
@@ -144,7 +144,7 @@ class EccBase(SndMotor, PositionerBase):
         Returns
         -------
         Status
-            Inputted status object.        
+            Inputted status object.
         """
         try:
             # Wait for the status to complete
@@ -220,7 +220,7 @@ class EccBase(SndMotor, PositionerBase):
         enabled : bool
             True if the motor is powered, False if not.
         """
-        return bool(self.motor_enable.value)
+        return bool(self.motor_enable.get())
 
     @property
     def connected(self):
@@ -232,7 +232,7 @@ class EccBase(SndMotor, PositionerBase):
         connected : bool
             True if the motor is connected, False if not.
         """
-        return bool(self.motor_connected.value)
+        return bool(self.motor_connected.get())
 
     @property
     def referenced(self):
@@ -244,19 +244,19 @@ class EccBase(SndMotor, PositionerBase):
         referenced : bool
             True if the motor is referenced, False if not.
         """
-        return bool(self.motor_referenced.value)
-    
+        return bool(self.motor_referenced.get())
+
     @property
     def error(self):
         """
         Returns the current error with the motor.
-        
+
         Returns
         -------
         error : bool
             Error enumeration.
         """
-        return bool(self.motor_error.value)
+        return bool(self.motor_error.get())
 
     def reset(self, ret_status=False, print_set=True):
         """
@@ -264,13 +264,13 @@ class EccBase(SndMotor, PositionerBase):
 
         Returns
         -------
-        status : StatusObject        
+        status : StatusObject
             Status object for the set.
         """
         status = self.motor_reset.set(1, timeout=self.set_timeout)
         return self._status_print(status, "Reset motor '{0}'".format(
             self.desc), ret_status=ret_status, print_set=print_set)
-    
+
     def move(self, position, check_status=True, timeout=None, *args, **kwargs):
         """
         Move to a specified position.
@@ -285,17 +285,17 @@ class EccBase(SndMotor, PositionerBase):
 
         Returns
         -------
-        status : MoveStatus        
+        status : MoveStatus
             Status object for the move.
-        
+
         Raises
         ------
         TimeoutError
             When motion takes longer than `timeout`
-        
+
         ValueError
             On invalid positions
-        
+
         RuntimeError
             If motion fails other than timing out
         """
@@ -328,7 +328,7 @@ class EccBase(SndMotor, PositionerBase):
         -----------------
         LimitError
             Error raised when the inputted position is beyond the soft limits.
-        
+
         MotorDisabled
             Error raised if the motor is disabled and move is requested.
 
@@ -337,7 +337,7 @@ class EccBase(SndMotor, PositionerBase):
 
         Returns
         -------
-        status : MoveStatus        
+        status : MoveStatus
             Status object for the move.
         """
         try:
@@ -361,7 +361,7 @@ class EccBase(SndMotor, PositionerBase):
             logger.warning("Cannot move - motor {0} is currently faulted. Try "
                            "running 'motor.clear()'.".format(self.desc))
 
-    
+
     def check_status(self, position=None):
         """
         Checks the status of the motor to make sure it is ready to move. Checks
@@ -394,7 +394,7 @@ class EccBase(SndMotor, PositionerBase):
         # Check if the current position is valid
         self.check_value(self.position)
         # Check if the move position is valid
-        if position: 
+        if position:
             self.check_value(position)
 
     def check_value(self, position):
@@ -444,7 +444,7 @@ class EccBase(SndMotor, PositionerBase):
         status = self.motor_stop.set(1, wait=False, timeout=self.set_timeout)
         super().stop(success=success)
         return self._status_print(status, "Stopped motor '{0}'".format(
-            self.desc), ret_status=ret_status, print_set=print_set)        
+            self.desc), ret_status=ret_status, print_set=print_set)
 
     def expert_screen(self, print_msg=True):
         """
@@ -464,15 +464,15 @@ class EccBase(SndMotor, PositionerBase):
     def set_limits(self, llm, hlm):
         """
         Sets the limits of the motor. Alias for limits = (llm, hlm).
-        
+
         Parameters
         ----------
         llm : float
             Desired low limit.
-            
+
         hlm : float
             Desired low limit.
-        """        
+        """
         self.limits = (llm, hlm)
 
     @property
@@ -484,7 +484,7 @@ class EccBase(SndMotor, PositionerBase):
         -------
         high_limit : float
         """
-        return self.upper_ctrl_limit.value
+        return self.upper_ctrl_limit.get()
 
     @high_limit.setter
     def high_limit(self, value):
@@ -502,7 +502,7 @@ class EccBase(SndMotor, PositionerBase):
         -------
         low_limit : float
         """
-        return self.lower_ctrl_limit.value
+        return self.lower_ctrl_limit.get()
 
     @low_limit.setter
     def low_limit(self, value):
@@ -530,16 +530,16 @@ class EccBase(SndMotor, PositionerBase):
         self.low_limit = value[0]
         self.high_limit = value[1]
 
-    def status(self, status="", offset=0, print_status=True, newline=False, 
+    def status(self, status="", offset=0, print_status=True, newline=False,
                short=False):
         """
         Returns the status of the device.
-        
+
         Parameters
         ----------
         status : str, optional
             The string to append the status to.
-            
+
         offset : int, optional
             Amount to offset each line of the status.
 
@@ -560,11 +560,11 @@ class EccBase(SndMotor, PositionerBase):
         else:
             status += "{0}{1}\n".format(" "*offset, self.desc)
             status += "{0}PV: {1:>25}\n".format(" "*(offset+2), self.prefix)
-            status += "{0}Enabled: {1:>20}\n".format(" "*(offset+2), 
+            status += "{0}Enabled: {1:>20}\n".format(" "*(offset+2),
                                                      str(self.enabled))
-            status += "{0}Faulted: {1:>20}\n".format(" "*(offset+2), 
+            status += "{0}Faulted: {1:>20}\n".format(" "*(offset+2),
                                                      str(self.error))
-            status += "{0}Position: {1:>19}\n".format(" "*(offset+2), 
+            status += "{0}Position: {1:>19}\n".format(" "*(offset+2),
                                                       np.round(self.wm(), 6))
             status += "{0}Limits: {1:>21}\n".format(
                 " "*(offset+2), str((int(self.low_limit), int(self.high_limit))))

--- a/hxrsnd/plans/scans.py
+++ b/hxrsnd/plans/scans.py
@@ -20,11 +20,11 @@ from ..utils import as_list
 
 logger = logging.getLogger(__name__)
 
-def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True, 
+def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True,
                 md=None, *args, **kwargs):
     """
     Linear scan of a motor without a detector.
-    
+
     Performs a linear scan using the inputted motor, optionally using the
     diagnostics, and optionally moving the motor back to the original start
     position. This scan is different from the regular scan because it does not
@@ -43,7 +43,7 @@ def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True,
 
     num : int
         number of steps
-        
+
     use_diag : bool, optional
         Include the diagnostic motors in the scan.
 
@@ -56,7 +56,7 @@ def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True,
            'num_intervals': num - 1,
            'plan_args': {'num': num,
                          'motor': repr(motor),
-                         'start': start, 
+                         'start': start,
                          'stop': stop},
            'plan_name': 'daq_scan',
            'plan_pattern': 'linspace',
@@ -68,15 +68,15 @@ def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True,
 
     # Build the list of steps
     steps = np.linspace(**_md['plan_pattern_args'])
-    
+
     # Let's store this for now
     start = motor.position
-    
+
     # Define the inner scan
     # @stage_decorator([motor])
     @run_decorator(md=_md)
     def inner_scan():
-        
+
         for i, step in enumerate(steps):
             logger.info("\nStep {0}: Moving to {1}".format(i+1, step))
             grp = _short_uid('set')
@@ -92,10 +92,10 @@ def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True,
             yield Msg('set', motor, start, group=grp, *args, **kwargs)
             yield Msg('wait', None, group=grp)
 
-    return (yield from inner_scan())    
+    return (yield from inner_scan())
 
-def centroid_scan(detector, motor, start, stop, steps, average=None, 
-                  detector_fields=['stats2_centroid_x', 'stats2_centroid_y'], 
+def centroid_scan(detector, motor, start, stop, steps, average=None,
+                  detector_fields=['stats2_centroid_x', 'stats2_centroid_y'],
                   motor_fields=None, system=None, system_fields=None,
                   filters=None, return_to_start=True, *args, **kwargs):
     """
@@ -109,7 +109,7 @@ def centroid_scan(detector, motor, start, stop, steps, average=None,
     ----------
     detector : :class:`.BeamDetector`
         Detector from which to take the value measurements
-    
+
     motor : :class:`.Motor`
         Main motor to perform the scan
 
@@ -121,7 +121,7 @@ def centroid_scan(detector, motor, start, stop, steps, average=None,
 
     steps : int
         Number of steps to take
-    
+
     average : int, optional
         Number of averages to take for each measurement
 
@@ -133,7 +133,7 @@ def centroid_scan(detector, motor, start, stop, steps, average=None,
 
     system : list, optional
         Extra devices to include in the datastream as we measure the average
-        
+
     system_fields : list, optional
         Fields of the extra devices to add to the returned dataframe
 
@@ -143,8 +143,8 @@ def centroid_scan(detector, motor, start, stop, steps, average=None,
         :meth:`.apply_filters`
 
     return_to_start : bool, optional
-        Move the scan motor back to its initial position after the scan     
-    
+        Move the scan motor back to its initial position after the scan
+
     Returns
     -------
     df : pd.DataFrame
@@ -190,4 +190,4 @@ def centroid_scan(detector, motor, start, stop, steps, average=None,
 
     # Return the filled dataframe
     return df
-    
+

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class PneuBase(SndDevice):
     """
     Base class for the penumatics.
-    """    
+    """
     def status(self, status="", offset=0, print_status=True, newline=False):
         """
         Returns the status of the device.
@@ -23,7 +23,7 @@ class PneuBase(SndDevice):
         ----------
         status : str, optional
             The string to append the status to.
-            
+
         offset : int, optional
             Amount to offset each line of the status.
 
@@ -38,7 +38,7 @@ class PneuBase(SndDevice):
         status : str
             Status string.
         """
-        status += "{0}{1:<16}|{2:^16}\n".format(" "*offset, self.desc+"", 
+        status += "{0}{1:<16}|{2:^16}\n".format(" "*offset, self.desc+"",
                                                 self.position)
         if newline:
             status += "\n"
@@ -78,7 +78,7 @@ class ProportionalValve(PneuBase):
             logger.info("Valve currently open.")
         else:
             return self.valve.set(1, timeout=self.set_timeout)
-    
+
     def close(self):
         """
         Closes the valve.
@@ -87,7 +87,7 @@ class ProportionalValve(PneuBase):
             logger.info("Valve currently closed.")
         else:
             return self.valve.set(0, timeout=self.set_timeout)
-        
+
     @property
     def position(self):
         """
@@ -97,11 +97,11 @@ class ProportionalValve(PneuBase):
         -------
         position : str
             String saying the current position of the valve. Can be "OPEN" or
-            "CLOSED". 
+            "CLOSED".
         """
-        if self.valve.value == 1:
+        if self.valve.get() == 1:
             return "OPEN"
-        elif self.valve.value == 0:
+        elif self.valve.get() == 0:
             return "CLOSED"
         else:
             return "UNKNOWN"
@@ -129,7 +129,7 @@ class ProportionalValve(PneuBase):
             True if the valve is currently in the 'closed' position.
         """
         return (self.position == "CLOSED")
-    
+
 
 class PressureSwitch(PneuBase):
     """
@@ -141,7 +141,7 @@ class PressureSwitch(PneuBase):
         Pressure readbac signal.
     """
     pressure = Cmp(EpicsSignalRO, ":GPS")
-        
+
     @property
     def position(self):
         """
@@ -151,11 +151,11 @@ class PressureSwitch(PneuBase):
         -------
         position : str
             String saying the current position of the valve. Can be "OPEN" or
-            "CLOSED". 
+            "CLOSED".
         """
-        if self.pressure.value == 0:
+        if self.pressure.get() == 0:
             return "GOOD"
-        elif self.pressure.value == 1:
+        elif self.pressure.get() == 1:
             return "BAD"
         else:
             return "UNKNOWN"
@@ -231,7 +231,7 @@ class SndPneumatics(SndDevice):
         ----------
         status : str, optional
             The string to append the status to.
-            
+
         offset : int, optional
             Amount to offset each line of the status.
 
@@ -253,7 +253,7 @@ class SndPneumatics(SndDevice):
             status += valve.status(offset=offset+2, print_status=False)
         for pressure in self._pressure_switches:
             status += pressure.status(offset=offset+2, print_status=False)
-                    
+
         if newline:
             status += "\n"
         if print_status is True:

--- a/hxrsnd/tests/test_aerotech.py
+++ b/hxrsnd/tests/test_aerotech.py
@@ -50,11 +50,11 @@ def test_AeroBase_raises_MotorDisabled_if_moved_while_disabled():
 #     motor.enable()
 #     assert motor.enabled
 #     motor.limits = (0, 1)
-#     assert motor.user_setpoint.value != position
+#     assert motor.user_setpoint.get() != position
 #     time.sleep(0.5)
 #     motor(position, wait=False)
 #     time.sleep(0.1)
-#     assert motor.user_setpoint.value == position
+#     assert motor.user_setpoint.get() == position
 
 # Commented out for now because it causes travis to seg fault sometimes
 # def test_AeroBase_raises_MotorFaulted_if_moved_while_faulted():
@@ -64,4 +64,4 @@ def test_AeroBase_raises_MotorDisabled_if_moved_while_disabled():
 #     motor.axis_fault.sim_put(1)
 #     with pytest.raises(MotorFaulted):
 #         motor.move(10)
-        
+

--- a/hxrsnd/tests/test_attocube.py
+++ b/hxrsnd/tests/test_attocube.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 def test_attocube_devices_instantiate_and_run_ophyd_functions(dev):
     motor = fake_device(dev)
     assert(isinstance(motor.read(), OrderedDict))
-    assert(isinstance(motor.read_configuration(), OrderedDict))    
+    assert(isinstance(motor.read_configuration(), OrderedDict))
 
 def test_EccBase_raises_MotorDisabled_if_moved_while_disabled():
     motor = fake_device(EccBase)
@@ -58,8 +58,8 @@ def test_EccBase_raises_MotorError_if_moved_while_faulted():
 #     motor = EccBase("TEST")
 #     motor.enable()
 #     motor.limits = (0, 1)
-#     assert motor.user_setpoint.value != position
+#     assert motor.user_setpoint.get() != position
 #     time.sleep(0.25)
 #     motor(position, wait=False)
 #     time.sleep(0.1)
-#     assert motor.user_setpoint.value == position
+#     assert motor.user_setpoint.get() == position


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
`Signal.value` was deprecated in a recent version of ophyd, with a very verbose error message indicating why it happened and why you shouldn't be using it. 

This PR removes `.value` attribute access and replaces it with `.get()`.

## Motivation and Context
Related to "verbosity" issue in #99 

## How Has This Been Tested?
Tests are still passing locally.