### PR TITLE
FIX: aerotech mvinterface incompatibility

### DIFF
--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -234,8 +234,7 @@ class AeroBase(SndEpicsMotor):
         return super().move(position, wait=wait, timeout=timeout, *args,
                             **kwargs)
 
-    def mv(self, position, wait=True, print_move=True,
-           *args, **kwargs):
+    def mv(self, position, wait=True, print_move=True, *args, **kwargs):
         """
         Move to a specified position, optionally waiting for motion to
         complete. mv() is different from move() by catching all the common
@@ -278,7 +277,7 @@ class AeroBase(SndEpicsMotor):
             Status object for the move.
         """
         try:
-            status = self.move(position, wait=wait, *args, **kwargs)
+            status = super().mv(position, wait=wait, *args, **kwargs)
 
             # Notify the user that a motor has completed or the command is sent
             if print_move:

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -366,7 +366,7 @@ class EccBase(SndMotor, PositionerBase):
             Status object for the move.
         """
         try:
-            status = self.move(position, *args, **kwargs)
+            status = super().mv(position, *args, **kwargs)
 
             # Notify the user that a motor has completed or the command is sent
             if print_move:
@@ -443,9 +443,11 @@ class EccBase(SndMotor, PositionerBase):
 
         # Check if it is within the soft limits
         if not (self.low_limit <= position <= self.high_limit):
-            err_str = "Requested value {0} outside of range: [{1}, {2}]"
-            logger.warn(err_str.format(position, self.low_limit,
-                                       self.high_limit))
+            err_str = (
+                "Requested value {0} outside of range: [{1}, {2}]"
+                "".format(position, self.low_limit, self.high_limit)
+            )
+            logger.warn(err_str)
             raise LimitError(err_str)
 
     def stop(self, success=False, ret_status=False, print_set=True):

--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -281,8 +281,8 @@ class MacroBase(SndMotor):
             List of status objects for each motor that was involved in the move.
         """
         try:
-            return self.move(position, wait=wait, verify_move=verify_move,
-                             use_diag=use_diag, *args, **kwargs)
+            return super().mv(position, wait=wait, verify_move=verify_move,
+                              use_diag=use_diag, *args, **kwargs)
         # Catch all the common motor exceptions
         except LimitError:
             logger.warning("Requested move is outside the soft limits")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Closes #107 

Going to check attocube ones before proceeding with the merge.

## Motivation and Context
* The updated move interface was not compatible with the custom code present in hxrsnd.

## How Has This Been Tested?
* Tested with a simulation IOC and the split and delay device (https://github.com/pcdshub/sim-ioc/pull/3)
* `umv` and `umvr` work without issue:

```
In [2]: snd.t1.th1.enable()

In [3]: snd.t1.th1.umvr(1)
snd_t1_th1: (1.0000) [Complete.]
```