### PR TITLE
TST: update tests, update dep tag to match

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - coloredlogs
     - super_state_machine
     - pswalker >=1.0.2
-    - pcdsdevices >=2.3.0
+    - pcdsdevices >=4.0.0
     - pyepics
 
 test:

--- a/hxrsnd/tests/test_tower.py
+++ b/hxrsnd/tests/test_tower.py
@@ -27,9 +27,9 @@ def test_DelayTower_does_not_move_if_motors_not_ready():
     tower = fake_device(DelayTower, "TEST:SND:T1")
     tower.disable()
     time.sleep(.5)
-    tower.tth.limits = (-100, 100)
-    tower.th1.limits = (-100, 100)
-    tower.th2.limits = (-100, 100)
+    tower.tth.user_setpoint.sim_set_limits((-100, 100))
+    tower.th1.user_setpoint.sim_set_limits((-100, 100))
+    tower.th2.user_setpoint.sim_set_limits((-100, 100))
 
     tower.tth.user_setpoint.check_value = lambda x: None
     tower.th1.user_setpoint.check_value = lambda x: None
@@ -47,7 +47,7 @@ def test_ChannelCutTower_does_not_move_if_motors_not_ready():
     tower = fake_device(ChannelCutTower, "TEST:SND:T1")
     tower.disable()
     time.sleep(.5)
-    tower.th.limits = (-100, 100)
+    tower.th.user_setpoint.sim_set_limits((-100, 100))
     tower.th.user_setpoint.check_value = lambda x: None
 
     with pytest.raises(MotorDisabled):


### PR DESCRIPTION
As a consequence of pcdsdevices v4.0.0, the api used in these tests is no longer valid.

No functional changes to the library code.