### PR TITLE
TST: detector_scaling_walk_start_positions_are_valid with latest bluesky

### DIFF
--- a/hxrsnd/tests/test_plans_calibration.py
+++ b/hxrsnd/tests/test_plans_calibration.py
@@ -68,6 +68,9 @@ def test_calibration_centroid_scan_renames_columns_correctly(fresh_RE):
 
 def test_detector_scaling_walk_start_positions_are_valid(fresh_RE):
     camera = SynCamera(m1, m2, delay, name="camera")
+    m1.set(0)
+    m2.set(0)
+    delay.set(0)
     calib_motors = [m1, m2]
 
     def test_plan():


### PR DESCRIPTION
Ref https://github.com/pcdshub/pcds-envs/pull/199

<!--- Provide a general summary of your changes in the Title above -->
## Description
This fixes a test failure with the latest bluesky, where a test fixture changed underneath us.

## Motivation and Context
pcds-4.2.0 had a bluesky with a non-parametrized `RE` (which we import as `fresh_RE`) which passed just fine.  I reproduced the failure locally with just the latest bluesky and hxrsnd in pcds-4.2.0. Turns out it's simply because we're running the same test twice, re-using motors at different starting positions.

## How Has This Been Tested?
Test suite.