### PR TITLE
CI: use only latest, only latest will pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
+    - name: "Python - PIP"
 
 import:
   # This import enables a set of standard python jobs including:
@@ -45,4 +45,4 @@ import:
   #   - Documentation using doctr
   #   - Conda Package - uploaded to pcds-dev and pcds-tag
   #   - PyPI
-  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda.yml
+  - pcdshub/pcds-ci-helpers:travis/shared_configs/standard-python-conda-latest.yml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Use the latest-only (3.9-only) branch of the shared CI configs
Update the allow failures

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Anaconda upload did not run on the last tag because the 3.7/3.8 builds fail because pcdsdevices dependency
Did not get caught at PR because the PR did not run the travis somehow
