### PR TITLE
BUG: fix issue where macro motor readback was not hinted

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     - pswalker >=1.0.5
     - pcdsdevices >=4.0.0
     - pyepics
+  run_constrained:
+    - pyqt <5.15
 
 test:
   imports:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,10 +14,10 @@ build:
 
 requirements:
   build:
-    - python >=3.6
+    - python >=3.6,<3.10
     - setuptools
   run:
-    - python >=3.6
+    - python >=3.6,<3.10
     - ipython
     - numpy
     - pandas

--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -39,7 +39,7 @@ class MacroBase(SndMotor):
                      'status', 'wait', 'c', 'gap']
 
     # Set add_prefix to be blank so cmp doesnt append the parent prefix
-    readback = Cmp(AttributeSignal, "position", add_prefix='')
+    readback = Cmp(AttributeSignal, "position", add_prefix='', kind='hinted')
 
     def __init__(self, prefix, name=None, read_attrs=None, *args, **kwargs):
         read_attrs = read_attrs or ["readback"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Make the macromotor readbacks hinted

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Did not show up in the BEC LiveTable
https://jira.slac.stanford.edu/browse/LCLSECSD-1098

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has not been tested

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
It has not been documented
<!--
## Screenshots (if appropriate):
-->
