### PR TITLE
TST: fix issue with outdated test hotfix

### DIFF
--- a/hxrsnd/tests/conftest.py
+++ b/hxrsnd/tests/conftest.py
@@ -244,7 +244,9 @@ def fake_detector(detector, name="TEST"):
 # Hotfix area detector plugins for tests
 for comp in (PCDSAreaDetector.image1, PCDSAreaDetector.stats2):
     plugin_class = comp.cls
-    plugin_class.plugin_type = Cmp(Signal, value=plugin_class._plugin_type)
+    cpt = Cmp(Signal, value=plugin_class._plugin_type)
+    cpt.attr = 'plugin_type'
+    plugin_class.plugin_type = cpt
 
 # Hotfix make_fake_device for ophyd=1.2.0
 fake_device_cache[EpicsSignalWithRBV] = FakeEpicsSignal


### PR DESCRIPTION
A few tests here fail when run offline. I'm not sure why they pass on travis CI.

There are some really old "make the thing behave different in the test" instances that inevitably break over time.
I'm not really interested in finding a full better way to do these today- I just want to patch over it and move on.