### PR TITLE
BLD: remove upper python pin mistake

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,10 +14,10 @@ build:
 
 requirements:
   build:
-    - python >=3.6,<3.10
+    - python >=3.6
     - setuptools
   run:
-    - python >=3.6,<3.10
+    - python >=3.6
     - ipython
     - numpy
     - pandas


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove the upper pin on the python version dependency.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The upper pin here doesn't really fix any problems, it just makes life more difficult.

I want to tag without this restriction so we can easily find and address potential issues with running our environment in python 3.10.