### PR TITLE
ENH: add xcs3 hotfix (delay pseudo)

### DIFF
--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -12,12 +12,13 @@ from ophyd.sim import NullStatus
 from ophyd.status import wait as status_wait
 from ophyd.utils import LimitError
 from pcdsdevices.areadetector.detectors import PCDSAreaDetector
-from pcdsdevices.pseudopos import (PseudoPositioner, PseudoSingleInterface,
-                                   pseudo_position_argument, real_position_argument)
 from pcdsdevices.interface import BaseInterface
+from pcdsdevices.pseudopos import (PseudoPositioner, PseudoSingleInterface,
+                                   pseudo_position_argument,
+                                   real_position_argument)
 from pswalker.utils import field_prepend
 
-from .aerotech import InterRotationAero, InterLinearAero
+from .aerotech import InterLinearAero, InterRotationAero
 from .bragg import bragg_angle, cosd, sind
 from .exceptions import (BadN2Pressure, MotorDisabled, MotorFaulted,
                          MotorStopped)

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -8,7 +8,8 @@ import logging
 from ophyd import Component as Cmp
 
 from .diode import HamamatsuXMotionDiode, HamamatsuXYMotionCamDiode
-from .macromotor import DelayMacro, Energy1CCMacro, Energy1Macro, Energy2Macro, _SNDDelay
+from .macromotor import (DelayMacro, Energy1CCMacro, Energy1Macro,
+                         Energy2Macro, _SNDDelay)
 from .pneumatic import SndPneumatics
 from .snddevice import SndDevice
 from .tower import ChannelCutTower, DelayTower

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -8,7 +8,7 @@ import logging
 from ophyd import Component as Cmp
 
 from .diode import HamamatsuXMotionDiode, HamamatsuXYMotionCamDiode
-from .macromotor import DelayMacro, Energy1CCMacro, Energy1Macro, Energy2Macro
+from .macromotor import DelayMacro, Energy1CCMacro, Energy1Macro, Energy2Macro, _SNDDelay
 from .pneumatic import SndPneumatics
 from .snddevice import SndDevice
 from .tower import ChannelCutTower, DelayTower
@@ -98,6 +98,8 @@ class SplitAndDelay(SndDevice):
     E1_cc = Cmp(Energy1CCMacro, "", desc="CC Delay Energy")
     E2 = Cmp(Energy2Macro, "", desc="CC Energy")
     delay = Cmp(DelayMacro, "", desc="Delay")
+
+    _delaypseudo = Cmp(_SNDDelay, "", kind='omitted')
 
     def __init__(self, prefix, name=None, daq=None, RE=None, *args, **kwargs):
         super().__init__(prefix, name=name, *args, **kwargs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
For many years now, xcs3 has had a dev checkout hotfix for `hxrsnd` that adds a pseudopositioner that calculates the delay for the split and delay.

I added this here as-is with no changes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As part of https://jira.slac.stanford.edu/browse/ECS-6333 I'm wrangling dev hotfixes into tags.
This hotfix has been active forever, is innocuous, and doesn't interfere with anything else in the module.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively at xcs since forever ago

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR only (later, release notes)

<!--
## Screenshots (if appropriate):
-->
